### PR TITLE
Create two widgets for when text field and buttons need to be separated

### DIFF
--- a/lib/markdown_buttons.dart
+++ b/lib/markdown_buttons.dart
@@ -1,0 +1,240 @@
+import 'dart:io';
+import 'dart:ui';
+
+import 'package:expandable/expandable.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:markdown_editable_textinput/markdown_text_input.dart';
+import 'package:markdown_editable_textinput/markdown_text_input_field.dart';
+import 'package:translator/translator.dart';
+
+import 'format_markdown.dart';
+
+/// Buttons of a [MarkdownTextInput] for when they should be separated from the text field.
+/// Designed to be used in conjunction with [MarkdownTextInputField].
+class MarkdownButtons extends StatelessWidget {
+  /// Controller that controls the corresponding [MarkdownTextInputField].
+  final TextEditingController controller;
+
+  /// FocusNode used to request focus on the corresponding [MarkdownTextInputField].
+  final FocusNode focusNode;
+
+  /// List of actions the component can handle
+  final List<MarkdownType> actions;
+
+  /// If you prefer to use the dialog to insert links, you can choose to use the markdown syntax directly by setting [insertLinksByDialog] to false. In this case, the selected text will be used as label and link.
+  /// Default value is true.
+  final bool insertLinksByDialog;
+
+  /// Optional function to override the default image button action when [MarkdownType.image] is in [actions].
+  final Function? customImageButtonAction;
+
+  /// Constructor for [MarkdownButtons]
+  const MarkdownButtons({
+    required this.controller,
+    required this.focusNode,
+    this.actions = const [MarkdownType.bold, MarkdownType.italic, MarkdownType.title, MarkdownType.link, MarkdownType.list],
+    this.insertLinksByDialog = true,
+    this.customImageButtonAction,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return SizedBox(
+      height: 44,
+      child: Material(
+        color: Theme.of(context).cardColor,
+        borderRadius: const BorderRadius.only(bottomLeft: Radius.circular(10), bottomRight: Radius.circular(10)),
+        child: ListView(
+          scrollDirection: Axis.horizontal,
+          children: actions.map((MarkdownType type) {
+            switch (type) {
+              case MarkdownType.image:
+                return _basicInkwell(type, label: 'Image', customOnTap: customImageButtonAction);
+              case MarkdownType.title:
+                return ExpandableNotifier(
+                  child: Expandable(
+                    key: const Key('H#_button'),
+                    collapsed: ExpandableButton(
+                      child: const Center(
+                        child: Padding(
+                          padding: EdgeInsets.all(10),
+                          child: Text(
+                            'H#',
+                            style: TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
+                          ),
+                        ),
+                      ),
+                    ),
+                    expanded: Container(
+                      color: Colors.white10,
+                      child: Row(
+                        children: [
+                          for (int i = 1; i <= 6; i++)
+                            InkWell(
+                              key: Key('H${i}_button'),
+                              onTap: () => _onTap(MarkdownType.title, titleSize: i),
+                              child: Padding(
+                                padding: const EdgeInsets.all(10),
+                                child: Text(
+                                  'H$i',
+                                  style: TextStyle(fontSize: (18 - i).toDouble(), fontWeight: FontWeight.w700),
+                                ),
+                              ),
+                            ),
+                          ExpandableButton(
+                            child: const Padding(
+                              padding: EdgeInsets.all(10),
+                              child: Icon(
+                                Icons.close,
+                                semanticLabel: 'Close header options',
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                );
+              case MarkdownType.link:
+                return _basicInkwell(
+                  type,
+                  label: 'Link',
+                  customOnTap: !insertLinksByDialog
+                      ? null
+                      : () async {
+                          var text = controller.text.substring(controller.selection.start, controller.selection.end);
+
+                          var textController = TextEditingController()..text = text;
+                          var linkController = TextEditingController();
+                          var textFocus = FocusNode();
+                          var linkFocus = FocusNode();
+
+                          var color = Theme.of(context).colorScheme.secondary;
+                          var language = kIsWeb ? window.locale.languageCode : Platform.localeName.substring(0, 2);
+
+                          var textLabel = 'Text';
+                          var linkLabel = 'Link';
+                          try {
+                            var textTranslation = await GoogleTranslator().translate(textLabel, to: language);
+                            textLabel = textTranslation.text;
+
+                            var linkTranslation = await GoogleTranslator().translate(linkLabel, to: language);
+                            linkLabel = linkTranslation.text;
+                          } catch (e) {
+                            textLabel = 'Text';
+                            linkLabel = 'Link';
+                          }
+
+                          if (context.mounted) {
+                            await showDialog<void>(
+                                context: context,
+                                builder: (context) {
+                                  return Dialog(
+                                    insetPadding: const EdgeInsets.all(20),
+                                    child: Padding(
+                                      padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 30.0),
+                                      child: Column(
+                                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                                        mainAxisSize: MainAxisSize.min,
+                                        children: [
+                                          Padding(
+                                            padding: const EdgeInsets.only(bottom: 24.0),
+                                            child: Row(
+                                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                              children: [
+                                                Text('Insert Link', style: theme.textTheme.titleLarge),
+                                                GestureDetector(child: const Icon(Icons.close), onTap: () => Navigator.pop(context)),
+                                              ],
+                                            ),
+                                          ),
+                                          TextField(
+                                            controller: textController,
+                                            decoration: InputDecoration(
+                                              isDense: true,
+                                              hintText: 'example',
+                                              label: Text(textLabel),
+                                              labelStyle: TextStyle(color: color),
+                                              focusedBorder: OutlineInputBorder(borderSide: BorderSide(color: color, width: 2)),
+                                              enabledBorder: OutlineInputBorder(borderSide: BorderSide(color: color, width: 2)),
+                                            ),
+                                            autofocus: text.isEmpty,
+                                            focusNode: textFocus,
+                                            textInputAction: TextInputAction.next,
+                                            onSubmitted: (value) {
+                                              textFocus.unfocus();
+                                              FocusScope.of(context).requestFocus(linkFocus);
+                                            },
+                                          ),
+                                          const SizedBox(height: 10),
+                                          TextField(
+                                            controller: linkController,
+                                            decoration: InputDecoration(
+                                              isDense: true,
+                                              hintText: 'https://example.com',
+                                              label: Text(linkLabel),
+                                              labelStyle: TextStyle(color: color),
+                                              focusedBorder: OutlineInputBorder(borderSide: BorderSide(color: color, width: 2)),
+                                              enabledBorder: OutlineInputBorder(borderSide: BorderSide(color: color, width: 2)),
+                                            ),
+                                            autofocus: text.isNotEmpty,
+                                            focusNode: linkFocus,
+                                          ),
+                                          const SizedBox(height: 10),
+                                          Align(
+                                            alignment: Alignment.centerRight,
+                                            child: TextButton(
+                                              onPressed: () {
+                                                _onTap(type, link: linkController.text, selectedText: textController.text);
+                                                Navigator.pop(context);
+                                              },
+                                              child: const Text('Insert'),
+                                            ),
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                  );
+                                });
+                          }
+                        },
+                );
+              default:
+                return _basicInkwell(type, label: type.name);
+            }
+          }).toList(),
+        ),
+      ),
+    );
+  }
+
+  Widget _basicInkwell(MarkdownType type, {required String label, Function? customOnTap}) {
+    return InkWell(
+      key: Key(type.key),
+      onTap: () => customOnTap != null ? customOnTap() : _onTap(type),
+      child: Padding(
+        padding: const EdgeInsets.all(10),
+        child: Icon(type.icon, semanticLabel: label),
+      ),
+    );
+  }
+
+  void _onTap(MarkdownType type, {int titleSize = 1, String? link, String? selectedText}) {
+    var noTextSelected = (controller.selection.start - controller.selection.end) == 0;
+
+    var fromIndex = controller.selection.start;
+    var toIndex = controller.selection.end;
+
+    final result =
+        FormatMarkdown.convertToMarkdown(type, controller.text, fromIndex, toIndex, titleSize: titleSize, link: link, selectedText: selectedText ?? controller.text.substring(fromIndex, toIndex));
+
+    controller.value = controller.value.copyWith(text: result.data, selection: TextSelection.collapsed(offset: fromIndex + result.cursorIndex));
+
+    if (noTextSelected) {
+      controller.selection = TextSelection.collapsed(offset: controller.selection.end - result.replaceCursorIndex);
+    }
+
+    focusNode.requestFocus();
+  }
+}

--- a/lib/markdown_text_input_field.dart
+++ b/lib/markdown_text_input_field.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:markdown_editable_textinput/markdown_buttons.dart';
+import 'package:markdown_editable_textinput/markdown_text_input.dart';
+
+/// Text field of a [MarkdownTextInput] for when it should be separated from the buttons.
+/// Designed to be used in conjunction with [MarkdownButtons].
+class MarkdownTextInputField extends StatefulWidget {
+  /// Callback called when text changed
+  final Function? onTextChanged;
+
+  /// Initial value you want to display
+  final String initialValue;
+
+  /// Validator for the TextFormField
+  final String? Function(String? value)? validators;
+
+  /// String displayed at hintText in TextFormField
+  final String? label;
+
+  /// Change the text direction of the input (RTL / LTR)
+  final TextDirection textDirection;
+
+  /// The maximum of lines that can be displayed in the input.
+  /// If this is null, there is no limit to the number of lines.
+  final int? maxLines;
+
+  /// The minimum number of lines to occupy when the content spans fewer lines.
+  /// If this is null, starts with enough vertical space for one line.
+  final int? minLines;
+
+  /// Controller that controls this text field. The same controller must be
+  /// given to the corresponding [MarkdownButtons].
+  final TextEditingController controller;
+
+  /// [FocusNode] used to request focus on this text field. The same [FocusNode]
+  /// must be given to the corresponding [MarkdownButtons].
+  final FocusNode focusNode;
+
+  /// Overrides input text style
+  final TextStyle? textStyle;
+
+  /// Constructor for [MarkdownTextInputField]
+  const MarkdownTextInputField({
+    required this.controller,
+    required this.focusNode,
+    this.onTextChanged,
+    this.initialValue = '',
+    this.label = '',
+    this.validators,
+    this.textDirection = TextDirection.ltr,
+    this.minLines,
+    this.maxLines,
+    this.textStyle,
+  });
+
+  @override
+  State createState() => _MarkdownTextInputFieldState();
+}
+
+class _MarkdownTextInputFieldState extends State<MarkdownTextInputField> {
+  @override
+  void initState() {
+    widget.controller.text = widget.initialValue;
+    if (widget.controller.selection.baseOffset == -1) {
+      widget.controller.selection = const TextSelection.collapsed(offset: 0);
+    }
+    if (widget.onTextChanged != null) {
+      widget.controller.addListener(() {
+        widget.onTextChanged!(widget.controller.text);
+      });
+    }
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: <Widget>[
+        TextFormField(
+          minLines: widget.minLines,
+          focusNode: widget.focusNode,
+          textInputAction: TextInputAction.newline,
+          maxLines: widget.maxLines,
+          controller: widget.controller,
+          textCapitalization: TextCapitalization.sentences,
+          validator: widget.validators != null ? (value) => widget.validators!(value) : null,
+          style: widget.textStyle ?? Theme.of(context).textTheme.bodyLarge,
+          cursorColor: Theme.of(context).textTheme.bodyLarge?.color,
+          textDirection: widget.textDirection,
+          decoration: InputDecoration(
+            border: InputBorder.none,
+            hintText: widget.label,
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
Creates two widgets `MarkdownTextInputField` and `MarkdownButtons` by more or less splitting  `MarkdownTextInput` into two. This allows, for example, to stick the buttons to the bottom of the screen while having the text field inside a scroll view.