### PR TITLE
Make initialValue optional and add imageIsLoading

### DIFF
--- a/lib/markdown_buttons.dart
+++ b/lib/markdown_buttons.dart
@@ -29,6 +29,9 @@ class MarkdownButtons extends StatelessWidget {
   /// Optional function to override the default image button action when [MarkdownType.image] is in [actions].
   final Function? customImageButtonAction;
 
+  /// When true, image icon is replaced by a [CircularProgressIndicator].
+  final bool imageIsLoading;
+
   /// Constructor for [MarkdownButtons]
   const MarkdownButtons({
     required this.controller,
@@ -36,6 +39,7 @@ class MarkdownButtons extends StatelessWidget {
     this.actions = const [MarkdownType.bold, MarkdownType.italic, MarkdownType.title, MarkdownType.link, MarkdownType.list],
     this.insertLinksByDialog = true,
     this.customImageButtonAction,
+    this.imageIsLoading = false,
   });
 
   @override
@@ -51,6 +55,20 @@ class MarkdownButtons extends StatelessWidget {
           children: actions.map((MarkdownType type) {
             switch (type) {
               case MarkdownType.image:
+                if (imageIsLoading) {
+                  return const Padding(
+                    padding: EdgeInsets.all(10.0),
+                    child: SizedBox(
+                        width: 24,
+                        height: 24,
+                        child: Center(
+                            child: SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator(),
+                        ))),
+                  );
+                }
                 return _basicInkwell(type, label: 'Image', customOnTap: customImageButtonAction);
               case MarkdownType.title:
                 return ExpandableNotifier(

--- a/lib/markdown_buttons.dart
+++ b/lib/markdown_buttons.dart
@@ -63,8 +63,8 @@ class MarkdownButtons extends StatelessWidget {
                         height: 24,
                         child: Center(
                             child: SizedBox(
-                          width: 20,
-                          height: 20,
+                          width: 18,
+                          height: 18,
                           child: CircularProgressIndicator(),
                         ))),
                   );

--- a/lib/markdown_text_input_field.dart
+++ b/lib/markdown_text_input_field.dart
@@ -10,7 +10,7 @@ class MarkdownTextInputField extends StatefulWidget {
   final Function? onTextChanged;
 
   /// Initial value you want to display
-  final String initialValue;
+  final String? initialValue;
 
   /// Validator for the TextFormField
   final String? Function(String? value)? validators;
@@ -45,7 +45,7 @@ class MarkdownTextInputField extends StatefulWidget {
     required this.controller,
     required this.focusNode,
     this.onTextChanged,
-    this.initialValue = '',
+    this.initialValue,
     this.label = '',
     this.validators,
     this.textDirection = TextDirection.ltr,
@@ -61,7 +61,9 @@ class MarkdownTextInputField extends StatefulWidget {
 class _MarkdownTextInputFieldState extends State<MarkdownTextInputField> {
   @override
   void initState() {
-    widget.controller.text = widget.initialValue;
+    if (widget.initialValue != null) {
+      widget.controller.text = widget.initialValue!;
+    }
     if (widget.controller.selection.baseOffset == -1) {
       widget.controller.selection = const TextSelection.collapsed(offset: 0);
     }


### PR DESCRIPTION
Two small changes that should help with the create post/comment pages on thunder. 

The change in `markdown_text_input_field` allows to keep the value of the controller, which is necessary to remember the cursor location when switching from preview. 

The change in `markdown_buttons` is a cosmetic change to turn the image button into a progress indicator while an image is being uploaded.

@hjiangsu 