### PR TITLE
Add markdown buttons for mentions

### DIFF
--- a/lib/format_markdown.dart
+++ b/lib/format_markdown.dart
@@ -7,8 +7,7 @@ class FormatMarkdown {
   /// Use [fromIndex] and [toIndex] for converting part of [data]
   /// [titleSize] is used for markdown titles
   /// [link] is used for link conversion type
-  static ResultMarkdown convertToMarkdown(MarkdownType type, String data, int fromIndex, int toIndex,
-      {int titleSize = 1, String? link, String selectedText = ''}) {
+  static ResultMarkdown convertToMarkdown(MarkdownType type, String data, int fromIndex, int toIndex, {int titleSize = 1, String? link, String selectedText = ''}) {
     late String changedData;
     late int replaceCursorIndex;
 
@@ -73,8 +72,7 @@ class FormatMarkdown {
 
     final cursorIndex = changedData.length;
 
-    return ResultMarkdown(data.substring(0, fromIndex) + changedData + data.substring(toIndex, data.length),
-        cursorIndex, replaceCursorIndex);
+    return ResultMarkdown(data.substring(0, fromIndex) + changedData + data.substring(toIndex, data.length), cursorIndex, replaceCursorIndex);
   }
 }
 
@@ -130,6 +128,12 @@ enum MarkdownType {
 
   /// For ![Alt text](link)
   image,
+
+  /// For [@username@instance.tld](https://instance.tld/u/username)
+  username,
+
+  /// For [!community@instance.tld](https://instance.tld/c/community)
+  community,
 }
 
 /// Add data to [MarkdownType] enum
@@ -157,6 +161,10 @@ extension MarkownTypeExtension on MarkdownType {
         return 'separator_button';
       case MarkdownType.image:
         return 'image_button';
+      case MarkdownType.username:
+        return 'username_button';
+      case MarkdownType.community:
+        return 'community_button';
     }
   }
 
@@ -183,6 +191,10 @@ extension MarkownTypeExtension on MarkdownType {
         return Icons.minimize_rounded;
       case MarkdownType.image:
         return Icons.image_rounded;
+      case MarkdownType.username:
+        return Icons.alternate_email_rounded;
+      case MarkdownType.community:
+        return IconData(0x0021);
     }
   }
 }

--- a/lib/markdown_buttons.dart
+++ b/lib/markdown_buttons.dart
@@ -31,6 +31,9 @@ class MarkdownButtons extends StatelessWidget {
   /// When true, image icon is replaced by a [CircularProgressIndicator].
   final bool imageIsLoading;
 
+  /// Allows overriding tap actions
+  final Map<MarkdownType, void Function()>? customTapActions;
+
   /// Constructor for [MarkdownButtons]
   const MarkdownButtons({
     required this.controller,
@@ -39,6 +42,7 @@ class MarkdownButtons extends StatelessWidget {
     this.insertLinksByDialog = true,
     this.customImageButtonAction,
     this.imageIsLoading = false,
+    this.customTapActions,
   });
 
   @override
@@ -218,8 +222,13 @@ class MarkdownButtons extends StatelessWidget {
 
   Widget _basicInkwell(MarkdownType type, {required String label, Function? customOnTap}) {
     return InkWell(
+      customBorder: const CircleBorder(),
       key: Key(type.key),
-      onTap: () => customOnTap != null ? customOnTap() : _onTap(type),
+      onTap: () => customTapActions?.containsKey(type) == true
+          ? customTapActions![type]!()
+          : customOnTap != null
+              ? customOnTap()
+              : _onTap(type),
       child: Padding(
         padding: const EdgeInsets.all(10),
         child: Icon(type.icon, semanticLabel: label),


### PR DESCRIPTION
This PR adds two new actions to the set of available markdown buttons, plus the ability to define custom tap handlers. See thunder-app/thunder#751 for more info.