### PR TITLE
update translator dep

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,9 +12,10 @@ dependencies:
     sdk: flutter
   effective_dart: ^1.3.2
   expandable: ^5.0.1
-  translator: ^0.1.7
-
-
+  translator:
+    git:
+      url: https://github.com/gwbischof/translator.git
+      ref: 8ece7f8f07d74100dc327f4ff319202131b0625c
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
translator is a dead project and depends on `http 0.x`
I forked the translator and bumped the http version.

This could be a good alternative; it is based on the `translate` package: 
https://pub.dev/packages/simplytranslate
https://github.com/Persie0/SimplyTranslate-dart

But it might be its own project to swap out the translator.

