### PR TITLE
Remove the translator dependency

### DIFF
--- a/lib/markdown_buttons.dart
+++ b/lib/markdown_buttons.dart
@@ -6,7 +6,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:markdown_editable_textinput/markdown_text_input.dart';
 import 'package:markdown_editable_textinput/markdown_text_input_field.dart';
-import 'package:translator/translator.dart';
 
 import 'format_markdown.dart';
 

--- a/lib/markdown_buttons.dart
+++ b/lib/markdown_buttons.dart
@@ -133,16 +133,6 @@ class MarkdownButtons extends StatelessWidget {
 
                           var textLabel = 'Text';
                           var linkLabel = 'Link';
-                          try {
-                            var textTranslation = await GoogleTranslator().translate(textLabel, to: language);
-                            textLabel = textTranslation.text;
-
-                            var linkTranslation = await GoogleTranslator().translate(linkLabel, to: language);
-                            linkLabel = linkTranslation.text;
-                          } catch (e) {
-                            textLabel = 'Text';
-                            linkLabel = 'Link';
-                          }
 
                           if (context.mounted) {
                             await showDialog<void>(

--- a/lib/markdown_text_input.dart
+++ b/lib/markdown_text_input.dart
@@ -5,7 +5,6 @@ import 'package:expandable/expandable.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:markdown_editable_textinput/format_markdown.dart';
-import 'package:translator/translator.dart';
 
 /// Widget with markdown buttons
 class MarkdownTextInput extends StatefulWidget {

--- a/lib/markdown_text_input.dart
+++ b/lib/markdown_text_input.dart
@@ -203,16 +203,6 @@ class _MarkdownTextInputState extends State<MarkdownTextInput> {
 
                                 var textLabel = 'Text';
                                 var linkLabel = 'Link';
-                                try {
-                                  var textTranslation = await GoogleTranslator().translate(textLabel, to: language);
-                                  textLabel = textTranslation.text;
-
-                                  var linkTranslation = await GoogleTranslator().translate(linkLabel, to: language);
-                                  linkLabel = linkTranslation.text;
-                                } catch (e) {
-                                  textLabel = 'Text';
-                                  linkLabel = 'Link';
-                                }
 
                                 await showDialog<void>(
                                     context: context,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,8 +12,6 @@ dependencies:
     sdk: flutter
   effective_dart: ^1.3.2
   expandable: ^5.0.1
-  translator: ^0.1.7
-
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
translator is a dead project and depends on http 0.x

@hjiangsu suggested that we don't use the translator dependency, and maybe we should remove it.
https://github.com/thunder-app/markdown-editor/pull/4#issuecomment-1741262854

This PR removes the translator dependency.

Translator was only used for translating a couple of labels, it was really easy to pull it out.
Thunder app is building with these changes, I'm not quite sure how to test it well, the floating button to create a new post on my linux build isn't working, but that is probably not related.
