### PR TITLE
Support alternative text selection

### DIFF
--- a/lib/src/format_markdown.dart
+++ b/lib/src/format_markdown.dart
@@ -11,9 +11,6 @@ class FormatMarkdown {
     /// String to convert
     String data,
 
-    /// An alternate data source on which to perform formatting
-    String? alternateData,
-
     /// Start index when converting part of [data]
     int fromIndex,
 
@@ -27,6 +24,9 @@ class FormatMarkdown {
 
     /// The curently selected text
     String selectedText = '',
+
+    /// An alternate data source on which to perform formatting
+    String? alternateData,
   }) {
     late String changedData;
     late int replaceCursorIndex;
@@ -74,7 +74,7 @@ class FormatMarkdown {
         break;
       case MarkdownType.blockquote:
         var index = 0;
-        final splitedData = (alternateData ?? data.substring(fromIndex, toIndex)).split('\n');
+        final splitedData = (data.isEmpty ? (alternateData ?? '') : data.substring(fromIndex, toIndex)).split('\n');
         changedData = splitedData.map((value) {
           index++;
           return index == splitedData.length ? '> $value' : '> $value\n';

--- a/lib/src/format_markdown.dart
+++ b/lib/src/format_markdown.dart
@@ -11,6 +11,9 @@ class FormatMarkdown {
     /// String to convert
     String data,
 
+    /// An alternate data source on which to perform formatting
+    String? alternateData,
+
     /// Start index when converting part of [data]
     int fromIndex,
 
@@ -71,7 +74,7 @@ class FormatMarkdown {
         break;
       case MarkdownType.blockquote:
         var index = 0;
-        final splitedData = data.substring(fromIndex, toIndex).split('\n');
+        final splitedData = (alternateData ?? data.substring(fromIndex, toIndex)).split('\n');
         changedData = splitedData.map((value) {
           index++;
           return index == splitedData.length ? '> $value' : '> $value\n';

--- a/lib/src/markdown_toolbar.dart
+++ b/lib/src/markdown_toolbar.dart
@@ -227,12 +227,12 @@ class MarkdownToolbar extends StatelessWidget {
     ResultMarkdown result = FormatMarkdown.convertToMarkdown(
       type,
       controller.text,
-      getAlternativeSelection?.call(),
       fromIndex,
       toIndex,
       titleSize: titleSize,
       link: link,
       selectedText: selectedText ?? controller.text.substring(fromIndex, toIndex),
+      alternateData: getAlternativeSelection?.call(),
     );
 
     controller.value = controller.value.copyWith(text: result.data, selection: TextSelection.collapsed(offset: fromIndex + result.cursorIndex));

--- a/lib/src/markdown_toolbar.dart
+++ b/lib/src/markdown_toolbar.dart
@@ -33,6 +33,9 @@ class MarkdownToolbar extends StatelessWidget {
   /// Allows overriding tap actions for each [MarkdownType]
   final Map<MarkdownType, void Function()>? customTapActions;
 
+  /// A function which allows the widget's parent to provide an alternate text selection
+  final String? Function()? getAlternativeSelection;
+
   /// Constructor for [MarkdownToolbar]
   const MarkdownToolbar({
     super.key,
@@ -43,6 +46,7 @@ class MarkdownToolbar extends StatelessWidget {
     this.customImageButtonAction,
     this.imageIsLoading = false,
     this.customTapActions,
+    this.getAlternativeSelection,
   });
 
   @override
@@ -223,6 +227,7 @@ class MarkdownToolbar extends StatelessWidget {
     ResultMarkdown result = FormatMarkdown.convertToMarkdown(
       type,
       controller.text,
+      getAlternativeSelection?.call(),
       fromIndex,
       toIndex,
       titleSize: titleSize,


### PR DESCRIPTION
Add the ability to provide an alternate selection as the basis of markdown actions. The specific use case here is to allow us to "quote" text that comes from outside our editor.

See: https://github.com/thunder-app/thunder/pull/1374

https://github.com/thunder-app/markdown-editor/assets/7417301/84145d2a-81d0-439d-8c07-77e9ae4c7020